### PR TITLE
exercise_3_add_remove_transaction_support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
 	<properties>
 		<swagger-version>1.5.7</swagger-version>
 		<java-version>1.8</java-version>
+
+		<testng.version>6.14.3</testng.version>
 	</properties>
 
 	<dependencies>
@@ -45,6 +47,14 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Test NG -->
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+			<version>${testng.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/com/test/recruitment/controller/TransactionController.java
+++ b/src/main/java/com/test/recruitment/controller/TransactionController.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -33,4 +34,15 @@ public interface TransactionController {
 	ResponseEntity<Page<TransactionResponse>> getTransactionsByAccount(
 			@PathVariable("accountId") String accountId,
 			@PageableDefault Pageable p);
+
+	/**
+	 * Delete {@link com.test.recruitment.entity.Transaction} with provided id
+	 *
+	 * @param accountId     account id of transaction
+	 * @param transactionId the transaction id
+	 * @return empty body with NO_CONTENT(204) status code
+	 */
+	@DeleteMapping(value = "/{transactionId}")
+	ResponseEntity<Void> delete(@PathVariable("accountId") String accountId,
+								@PathVariable("transactionId") String transactionId);
 }

--- a/src/main/java/com/test/recruitment/controller/impl/TransactionControllerImpl.java
+++ b/src/main/java/com/test/recruitment/controller/impl/TransactionControllerImpl.java
@@ -44,4 +44,13 @@ public class TransactionControllerImpl implements TransactionController {
 		}
 		return ResponseEntity.ok().body(page);
 	}
+
+    @Override
+	// ToDo security @PreAuthorize("hasRole('ROLE_ADMIN')") after Spring Security(for example) initialization
+    public ResponseEntity<Void> delete(@PathVariable("accountId") String accountId,
+                                       @PathVariable("transactionId") String transactionId) {
+        transactionService.deleteById(accountId, transactionId);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/test/recruitment/dao/TransactionRepository.java
+++ b/src/main/java/com/test/recruitment/dao/TransactionRepository.java
@@ -33,4 +33,11 @@ public interface TransactionRepository {
 	 * @return
 	 */
 	Page<Transaction> getTransactionsByAccount(String accountId, Pageable p);
+
+	/**
+	 * Delete transaction by provided id
+	 *
+	 * @param transactionId the transaction id
+	 */
+	void deleteById(String transactionId);
 }

--- a/src/main/java/com/test/recruitment/dao/impl/TransactionRepositoryImpl.java
+++ b/src/main/java/com/test/recruitment/dao/impl/TransactionRepositoryImpl.java
@@ -70,4 +70,8 @@ public class TransactionRepositoryImpl implements TransactionRepository,
 				.collect(Collectors.toList()));
 	}
 
+	@Override
+	public void deleteById(String transactionId) {
+		transactions.removeIf(transaction -> transaction.getId().equals(transactionId));
+	}
 }

--- a/src/main/java/com/test/recruitment/json/ErrorCode.java
+++ b/src/main/java/com/test/recruitment/json/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode {
 
 	NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND),
 	NOT_FOUND_TRANSACTION(HttpStatus.NOT_FOUND),
-	FORBIDDEN_TRANSACTION(HttpStatus.FORBIDDEN);
+	FORBIDDEN_TRANSACTION(HttpStatus.FORBIDDEN),
+	INVALID_PARAMETERS(HttpStatus.BAD_REQUEST);
 
 	@Getter
 	private HttpStatus httpStatus;

--- a/src/main/java/com/test/recruitment/service/ExceptionHandlerService.java
+++ b/src/main/java/com/test/recruitment/service/ExceptionHandlerService.java
@@ -3,12 +3,11 @@ package com.test.recruitment.service;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.test.recruitment.json.ErrorResponse;
 import com.test.recruitment.exception.ServiceException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /**
  * Exception handler
@@ -17,7 +16,7 @@ import com.test.recruitment.exception.ServiceException;
  *
  */
 @Slf4j
-@ControllerAdvice
+@RestControllerAdvice
 public class ExceptionHandlerService {
 
 	/**
@@ -28,7 +27,6 @@ public class ExceptionHandlerService {
 	 * @return error response
 	 */
 	@ExceptionHandler(ServiceException.class)
-	@ResponseBody
 	public ResponseEntity<ErrorResponse> handleServiceException(
 			ServiceException e) {
 		log.error("Error : " + e.getMessage());

--- a/src/test/java/com/test/recruitment/tests/service/TransactionServiceTest.java
+++ b/src/test/java/com/test/recruitment/tests/service/TransactionServiceTest.java
@@ -1,0 +1,82 @@
+package com.test.recruitment.tests.service;
+
+import com.test.recruitment.dao.TransactionRepository;
+import com.test.recruitment.entity.Transaction;
+import com.test.recruitment.exception.ServiceException;
+import com.test.recruitment.service.TransactionService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Test(testName = "TransactionServiceTest")
+public class TransactionServiceTest {
+    private static final String VALID_ACCOUNT_ID = "2";
+    private static final String INVALID_ACCOUNT_ID = "4";
+    private static final String VALID_TRANSACTION_ID = "3";
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @InjectMocks
+    private TransactionService transactionService;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void processDeleteTransactionByIdSuccess() {
+        when(transactionRepository.findById(VALID_TRANSACTION_ID)).thenReturn(buildTransaction(VALID_ACCOUNT_ID));
+
+        transactionService.deleteById(VALID_ACCOUNT_ID, VALID_TRANSACTION_ID);
+
+        verify(transactionRepository).deleteById(VALID_TRANSACTION_ID);
+    }
+
+    @Test(expectedExceptions = ServiceException.class, expectedExceptionsMessageRegExp = "Transaction don't belongs to account")
+    public void processDeleteTransactionByIdAccountsDontMatch() {
+        when(transactionRepository.findById(VALID_TRANSACTION_ID)).thenReturn(buildTransaction(INVALID_ACCOUNT_ID));
+
+        transactionService.deleteById(VALID_TRANSACTION_ID, VALID_TRANSACTION_ID);
+    }
+
+    @Test(expectedExceptions = ServiceException.class, expectedExceptionsMessageRegExp = "Transaction doesn't exist")
+    public void processDeleteTransactionByIdNotFound() {
+        when(transactionRepository.findById(VALID_TRANSACTION_ID)).thenReturn(null);
+
+        transactionService.deleteById(VALID_ACCOUNT_ID, VALID_TRANSACTION_ID);
+    }
+
+    @Test(dataProvider = "missingInputData", expectedExceptions = ServiceException.class)
+    public void processDeleteTransactionByIdMissingRequiredParams(String accountId, String transactionId) {
+        transactionService.deleteById(accountId, transactionId);
+    }
+
+    @DataProvider(name = "missingInputData")
+    private Object[][] missingInputData() {
+        return new Object[][]{
+                {
+                        null, null
+                },
+                {
+                        VALID_ACCOUNT_ID, null
+                },
+                {
+                        null, VALID_TRANSACTION_ID
+                }
+        };
+    }
+
+    private Transaction buildTransaction(String accountId) {
+        Transaction transaction = new Transaction();
+        transaction.setAccountId(accountId);
+        return transaction;
+    }
+}


### PR DESCRIPTION
Remove functionality added in TransactionController since we need to protect our resources by Spring Security annotations in the feature.